### PR TITLE
Handle LOOP bit of custom BRR samples correctly

### DIFF
--- a/src/brr.c
+++ b/src/brr.c
@@ -22,7 +22,7 @@ void decode_samples(WORD *ptrtable) {
 		} while ((b & 1) == 0);
 
 		sa->length = ((end - start) / 9) * 16;
-		if (spc[start] & 2) {
+		if (b & 2) { // The LOOP bit only matters for the last brr block
 			if (loop < start || loop >= end)
 				continue;
 			sa->loop_len = ((end - loop) / 9) * 16;


### PR DESCRIPTION
EBMusEd originally checked only the first BRR block for the LOOP bit, but it turns out this was wrong all along. The LOOP bit only matters for the very last BRR block (it is ignored on every other block.)

The only reason this worked before is because looped samples in Earthbound have the LOOP bit set on every BRR block. For custom samples, this might not be the case, so this change makes EBMusEd recognize any looped sample.