### PR TITLE
Improve instruments 17, 18, 19

### DIFF
--- a/src/brr.c
+++ b/src/brr.c
@@ -47,15 +47,25 @@ void decode_samples(WORD *ptrtable) {
 				if (s >= 8) s -= 16;
 
 				s <<= range;
+				if (range > 12) {
+					if (s < 0) s = -4096;
+					else       s = 0;
+				}
+
 				if (filter) {
 					switch (filter) {
 						case 1: s += p[-1] * 15 >> 4; break;
 						case 2: s += (p[-1] * 61 >> 5) - (p[-2] * 15 >> 4); break;
 						case 3: s += (p[-1] * 115 >> 6) - (p[-2] * 13 >> 4); break;
 					}
-					if (s < -32768) s = -32768;
-					else if (s > 32767) s = 32767;
+					// Clamp to [-65536, 65534] and then have it wrap around at
+					// [-32768, 32767]
+					if (s < -65536) s = (-65536 + 65536);
+					else if (s > 65534) s = (65534 - 65536);
+					else if (s < -32768) s += 65536;
+					else if (s > 32767) s -= 65536;
 				}
+
 				*p++ = s;
 			}
 		}

--- a/src/inst.c
+++ b/src/inst.c
@@ -194,7 +194,7 @@ LRESULT CALLBACK InstrumentsWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM 
 		// Insert a custom window procedure on the instrument list, so we
 		// can see WM_KEYDOWN and WM_KEYUP messages for instrument testing.
 		// (LBS_WANTKEYBOARDINPUT doesn't notify on WM_KEYUP)
-		ListBoxWndProc = (WNDPROC)SetWindowLong(instlist, GWL_WNDPROC,
+		ListBoxWndProc = (WNDPROC)SetWindowLongPtr(instlist, GWLP_WNDPROC,
 			(LONG)InstListWndProc);
 
 		for (int i = 0; i < 128; i++) {

--- a/src/inst.c
+++ b/src/inst.c
@@ -195,7 +195,7 @@ LRESULT CALLBACK InstrumentsWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM 
 		// can see WM_KEYDOWN and WM_KEYUP messages for instrument testing.
 		// (LBS_WANTKEYBOARDINPUT doesn't notify on WM_KEYUP)
 		ListBoxWndProc = (WNDPROC)SetWindowLongPtr(instlist, GWLP_WNDPROC,
-			(LONG)InstListWndProc);
+			(LONG_PTR)InstListWndProc);
 
 		for (int i = 0; i < 128; i++) {
 			if (samp[i].data == NULL) continue;

--- a/src/tracker.c
+++ b/src/tracker.c
@@ -351,7 +351,7 @@ LRESULT CALLBACK EditorWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPara
 				hWnd, (HMENU)(IDC_ENABLE_CHANNEL_0 + i), hinstance, NULL);
 			SendMessage(b, BM_SETCHECK, chmask >> i & 1, 0);
 		}
-		EditWndProc = (WNDPROC)SetWindowLongPtr(GetDlgItem(hWnd, IDC_EDITBOX), GWLP_WNDPROC, (LONG)TrackEditWndProc);
+		EditWndProc = (WNDPROC)SetWindowLongPtr(GetDlgItem(hWnd, IDC_EDITBOX), GWLP_WNDPROC, (LONG_PTR)TrackEditWndProc);
 		break;
 	case WM_SONG_IMPORTED:
 	case WM_SONG_LOADED:

--- a/src/tracker.c
+++ b/src/tracker.c
@@ -351,7 +351,7 @@ LRESULT CALLBACK EditorWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPara
 				hWnd, (HMENU)(IDC_ENABLE_CHANNEL_0 + i), hinstance, NULL);
 			SendMessage(b, BM_SETCHECK, chmask >> i & 1, 0);
 		}
-		EditWndProc = (WNDPROC)SetWindowLong(GetDlgItem(hWnd, IDC_EDITBOX), GWL_WNDPROC, (LONG)TrackEditWndProc);
+		EditWndProc = (WNDPROC)SetWindowLongPtr(GetDlgItem(hWnd, IDC_EDITBOX), GWLP_WNDPROC, (LONG)TrackEditWndProc);
 		break;
 	case WM_SONG_IMPORTED:
 	case WM_SONG_LOADED:


### PR DESCRIPTION
The first commit has two changes I had to make to get EBMusEd to build with CodeBlocks/mingw-w64. According to Microsoft docs, it shouldn't affect the 32-bit build of the program. I didn't touch the `_ARGC`/`_ARGV` macros in this PR because I didn't know what to do with them.

The second commit changes the clamping logic in the BRR decoder to wrap after normal overflow and clamp after double the range. This makes instrument 18 sound basically perfect (see 2B: Belch Base, 8E: Teleporting to Magicant, 69: The Devil's Machine, and many others), and instrument 17 sounds mostly okay too in the songs in which it appears (7C: Enter Starman Junior and 8F: Leaving Magicant), though it's still very unpleasant in the instrument viewer. Instrument 19 doesn't sound quite right even in songs it appears in (15: Pokey's House), but it was affected and it sounds piercing and annoying. I have used snes_spc (license: GPL 2.1) as a reference for how the BRR decoding works on a real SNES; IANAL so I don't know how important that is.