### PR TITLE
Rewrite track loading to lessen assumptions about track ordering

### DIFF
--- a/src/ebmusv2.h
+++ b/src/ebmusv2.h
@@ -163,7 +163,7 @@ extern int check_range(int start, int end, int pack);
 extern char *decomp_error;
 BOOL validate_track(BYTE *data, int size, BOOL is_sub);
 int compile_song(struct song *s);
-BOOL decompile_song(struct song *s, int start_addr, int end_addr);
+void decompile_song(struct song *s, int start_addr, int end_addr);
 void free_song(struct song *s);
 
 // songed.c


### PR DESCRIPTION
Now, the song decompilation should be able to handle tracks that are out of order and that don't end in a zero byte when previously expected.

There are now two rules used for determining the end of a track.
First, tracks cannot overlap: track A ends where track B begins, if B is the first track following A.
Second, a track ends at a zero byte.
This means EBMusEd should never give the `Track can not contain [00]` error.