### PR TITLE
Fix state bug with empty tracks

### DIFF
--- a/src/tracker.c
+++ b/src/tracker.c
@@ -299,8 +299,9 @@ static void goto_order(int pos) {
 	initialize_state();
 	for (i = 0; i < pos; i++) {
 		int ch;
-		for (ch = 0; ch < 8 && state.chan[ch].ptr != NULL; ch++)
-		// an empty pattern will loop forever, so skip it
+		// Determine number of null tracks
+		for (ch = 0; ch < 8 && state.chan[ch].ptr == NULL; ch++) { /* do nothing */ }
+		// If some tracks were not null, then simulate them without generating audio.
 		if (ch != 8) {
 			while (do_cycle_no_sound(&state));
 		}

--- a/src/tracker.c
+++ b/src/tracker.c
@@ -298,12 +298,16 @@ static void goto_order(int pos) {
 	int i;
 	initialize_state();
 	for (i = 0; i < pos; i++) {
-		int ch;
-		// Determine number of null tracks
-		for (ch = 0; ch < 8 && state.chan[ch].ptr == NULL; ch++) { /* do nothing */ }
-		// If some tracks were not null, then simulate them without generating audio.
-		if (ch != 8) {
-			while (do_cycle_no_sound(&state));
+		// If there are any non-null tracks in this pattern, then
+		// we want to step through the whole pattern once by calling
+		// `do_cycle_no_sound` until it returns false.
+		for (int ch = 0; ch < 8; ch++) {
+			if (state.chan[ch].ptr != NULL) {
+				// We've found a non-null track. Simulate the current pattern.
+				while (do_cycle_no_sound(&state));
+				// We're done with the current pattern. Move on to the next one.
+				break;
+			}
 		}
 		load_pattern();
 	}


### PR DESCRIPTION
Fixes #6.
Here is a [zipped EBM](https://github.com/PKHackers/ebmused/files/7737135/state.bug.zip) that demonstrates the issue. To reproduce, open EBMusEd without the fix, go to pattern 1 and play. You should observe that the instrument set in pattern 0 does not carry over.