### PR TITLE
BRR decoding improvements and some cleanup

### DIFF
--- a/src/bgmlist.c
+++ b/src/bgmlist.c
@@ -118,7 +118,7 @@ void load_instruments() {
 			fread(&spc[addr], size, 1, rom);
 		}
 	}
-	decode_samples((WORD *)&spc[0x6C00]);
+	decode_samples(&spc[0x6C00]);
 	inst_base = 0x6E00;
 	if (samp[0].data == NULL)
 		song_playing = FALSE;

--- a/src/brr.c
+++ b/src/brr.c
@@ -1,3 +1,4 @@
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/brr.c
+++ b/src/brr.c
@@ -186,7 +186,7 @@ void decode_samples(const unsigned char *ptrtable) {
 			++times;
 		} while (needs_another_loop && times < 64);
 
-		if (times == 64) {
+		if (needs_another_loop) {
 			printf("Sample %02X took too many iterations to get into a cycle\n", sn);
 		}
 

--- a/src/brr.c
+++ b/src/brr.c
@@ -1,10 +1,74 @@
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "ebmusv2.h"
 
+enum {
+	BRR_BLOCK_SIZE = 9,
+
+	BRR_FLAG_END = 1,
+	BRR_FLAG_LOOP = 2
+};
+
 struct sample samp[128];
 
-void decode_samples(WORD *ptrtable) {
+// Returns the length of a BRR sample, in bytes
+static int32_t sample_length(const uint8_t *spc_memory, uint16_t start) {
+	int32_t end = start;
+	uint8_t b;
+	do {
+		b = spc_memory[end];
+		end += BRR_BLOCK_SIZE;
+	} while ((b & BRR_FLAG_END) == 0 && end < 0x10000 - 9);
+
+	if (end < 0x10000 - 9)
+		return end - start;
+	else
+		return -1;
+}
+
+static void decode_brr_block(int16_t *buffer, const uint8_t *block) {
+	int range = block[0] >> 4;
+	int filter = (block[0] >> 2) & 3;
+
+	for (int i = 2; i < 18; i++) {
+		int32_t s = block[i / 2];
+
+		if (i % 2 == 0) {
+			s >>= 4;
+		} else {
+			s &= 0x0F;
+		}
+
+		if (s >= 8) {
+			s -= 16;
+		}
+
+		s <<= range - 1;
+		if (range > 12) {
+			s = (s < 0) ? -(1 << 11) : 0;
+		}
+
+		switch (filter) {
+			case 1: s += (buffer[-1] * 15) >> 5; break;
+			case 2: s += ((buffer[-1] * 61) >> 6) - ((buffer[-2] * 15) >> 5); break;
+			case 3: s += ((buffer[-1] * 115) >> 7) - ((buffer[-2] * 13) >> 5); break;
+		}
+
+		s *= 2;
+
+		// Clamp to [-65536, 65534] and then have it wrap around at
+		// [-32768, 32767]
+		if (s < -0x10000) s = (-0x10000 + 0x10000);
+		else if (s > 0xFFFE) s = (0xFFFE - 0x10000);
+		else if (s < -0x8000) s += 0x10000;
+		else if (s > 0x7FFF) s -= 0x10000;
+
+		*buffer++ = s;
+	}
+}
+
+void decode_samples(const WORD *ptrtable) {
 	for (int sn = 0; sn < 128; sn++) {
 		struct sample *sa = &samp[sn];
 		int start = *ptrtable++;
@@ -14,70 +78,67 @@ void decode_samples(WORD *ptrtable) {
 		if (start == 0 || start == 0xffff)
 			continue;
 
-		int end = start;
-		int b;
-		do {
-			b = spc[end];
-			end += 9;
-		} while ((b & 1) == 0);
+		int length = sample_length(spc, start);
+		if (length == -1)
+			continue;
 
-		sa->length = ((end - start) / 9) * 16;
-		if (b & 2) { // The LOOP bit only matters for the last brr block
+		int end = start + length;
+		sa->length = (length / BRR_BLOCK_SIZE) * 16;
+		// The LOOP bit only matters for the last brr block
+		if (spc[start + length - BRR_BLOCK_SIZE] & BRR_FLAG_LOOP) {
 			if (loop < start || loop >= end)
 				continue;
-			sa->loop_len = ((end - loop) / 9) * 16;
+			sa->loop_len = ((end - loop) / BRR_BLOCK_SIZE) * 16;
 		} else
 			sa->loop_len = 0;
 
-		short *p = malloc(2 * (sa->length + 1));
+		size_t allocation_size = sizeof(int16_t) * (2 + sa->length + 1);
+
+		int16_t *p = malloc(allocation_size);
+		if (!p)
+			continue;
 /*		printf("Sample %2d: %04X(%04X)-%04X length %d looplen %d\n",
 			sn, start, loop, end, sa->length, sa->loop_len);*/
 
-		sa->data = p;
-		for (int pos = start; pos < end; pos += 9) {
-			int range = spc[pos] >> 4;
-			int filter = (spc[pos] >> 2) & 3;
-			for (int i = 2; i < 18; i++) {
-				int s = spc[pos + (i >> 1)];
-				if (i & 1)
-					s &= 15;
-				else
-					s >>= 4;
+		// A custom sample might try to rely on past data that doesn't exist, so provide some.
+		p[0] = 0;
+		p[1] = 0;
+		sa->data = &p[2];
+		p = &p[2];
 
-				if (s >= 8) s -= 16;
+		int needs_another_loop = FALSE;
 
-				s <<= range;
-				if (range > 12) {
-					if (s < 0) s = -4096;
-					else       s = 0;
-				}
-
-				if (filter) {
-					switch (filter) {
-						case 1: s += p[-1] * 15 >> 4; break;
-						case 2: s += (p[-1] * 61 >> 5) - (p[-2] * 15 >> 4); break;
-						case 3: s += (p[-1] * 115 >> 6) - (p[-2] * 13 >> 4); break;
-					}
-					// Clamp to [-65536, 65534] and then have it wrap around at
-					// [-32768, 32767]
-					if (s < -65536) s = (-65536 + 65536);
-					else if (s > 65534) s = (65534 - 65536);
-					else if (s < -32768) s += 65536;
-					else if (s > 32767) s -= 65536;
-				}
-
-				*p++ = s;
+		do {
+			for (int pos = start; pos < end; pos += BRR_BLOCK_SIZE) {
+				decode_brr_block(p, &spc[pos]);
+				p += 16;
 			}
-		}
+
+			if (sa->loop_len) {
+				int16_t after_loop[18] = {0};
+				after_loop[0] = p[-2];
+				after_loop[1] = p[-1];
+
+				decode_brr_block(&after_loop[2], &spc[loop]);
+				needs_another_loop = after_loop[2] != sa->data[sa->length - sa->loop_len] ||
+									after_loop[3] != sa->data[sa->length - sa->loop_len + 1];
+				if (needs_another_loop) {
+					printf("We need another loop! sample %02X\n", (unsigned)sn);
+				}
+			}
+		} while (0 /* needs_another_loop */);
 
 		// Put an extra sample at the end for easier interpolation
 		*p = sa->loop_len ? sa->data[sa->length - sa->loop_len] : 0;
 	}
 }
 
-void free_samples() {
+void free_samples(void) {
 	for (int sn = 0; sn < 128; sn++) {
-		free(samp[sn].data);
+		if (samp[sn].data) {
+			// static_assert(sizeof(samp[sn].data[0]) == sizeof(int16_t));
+			free(samp[sn].data - 2);
+		}
 		samp[sn].data = NULL;
 	}
 }

--- a/src/ebmusv2.h
+++ b/src/ebmusv2.h
@@ -48,7 +48,7 @@ BOOL save_all_packs(void);
 
 // brr.c
 extern struct sample samp[128];
-void decode_samples(const WORD *ptrtable);
+void decode_samples(const unsigned char *ptrtable);
 void free_samples(void);
 
 // ctrltbl.c

--- a/src/ebmusv2.h
+++ b/src/ebmusv2.h
@@ -48,7 +48,7 @@ BOOL save_all_packs(void);
 
 // brr.c
 extern struct sample samp[128];
-void decode_samples(WORD *ptrtable);
+void decode_samples(const WORD *ptrtable);
 void free_samples(void);
 
 // ctrltbl.c


### PR DESCRIPTION
This PR combines some general refactoring of brr.c with a new feature that fixes the way instruments 17 and 19 sound. It's not really cleaned up yet but I wanted to create a PR before the week ended. Sorry about that.

* The first commit is mostly a reorganization of brr.c, though it adds some additional error checking in some places to prevent undefined behavior. It also changes the calculation a bit to be closer to "bit-perfect"; I figured this would result in cycles being shorter, since there are fewer possible values for a sample to have (LSB is always clear).
* The second commit adds the main feature: at the end of a sample, EBMusEd now checks to see if the sample would sound different when the first block is re-decoded, and if it does, it tries to decode the loop again and again until it finds a cycle. Many looping samples are apparently affected by this, to varying degrees (some samples take around 10 loops before they settle into a cycle), but the noise samples were hit hardest.
* The third commit changes a strategy introduced in the first commit, so there's slightly less confusing pointer arithmetic. It also should match what emulators (and probably real hardware?) do a little better.

Included in the first commit is code to handle failure for malloc, and the second commit includes realloc as well. There's a to-do comment left in the code about what to do if realloc fails. Right now, it just treats it the same way as the case where a cycle couldn't be found: it creates a loop segment with the last decoded loop portion of the sample. I'm interested in different ideas for what to do there, including whether doing nothing (like the rest of EBMusEd's code) is preferred.