### PR TITLE
Fixed accelerators to not trigger other events

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -484,8 +484,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	while (GetMessage(&msg, NULL, 0, 0) > 0) {
 		if (!TranslateAccelerator(hwndMain, hAccel, &msg)) {
 			TranslateMessage(&msg);
+			DispatchMessage(&msg);
 		}
-		DispatchMessage(&msg);
 	}
 	DestroyMenu(hcontextmenu);
 	return msg.wParam;


### PR DESCRIPTION
Fixed issue #16 where accelerators would trigger both two separate events, e.g. Cltr+S saving and inserting a note.