### PR TITLE
Implement all supported envelope features

### DIFF
--- a/src/ebmusv2.h
+++ b/src/ebmusv2.h
@@ -21,6 +21,7 @@
 #define WM_SONG_LOADED WM_USER+3
 #define WM_SONG_NOT_LOADED WM_USER+4
 #define WM_PACKS_SAVED WM_USER+5
+#define MAX_INSTRUMENTS 128
 
 // main.c
 extern BYTE packs_loaded[3];

--- a/src/ebmusv2.h
+++ b/src/ebmusv2.h
@@ -110,6 +110,7 @@ extern BYTE spc[65536];
 extern int inst_base;
 void set_inst(struct song_state *st, struct channel_state *c, int inst);
 void calc_freq(struct channel_state *c, int note16);
+short initial_env_height(BOOL adsr_on, unsigned char gain);
 void load_pattern(void);
 BOOL do_cycle_no_sound(struct song_state *st);
 BOOL do_timer(void);

--- a/src/ebmusv2.h
+++ b/src/ebmusv2.h
@@ -110,7 +110,7 @@ extern BYTE spc[65536];
 extern int inst_base;
 void set_inst(struct song_state *st, struct channel_state *c, int inst);
 void calc_freq(struct channel_state *c, int note16);
-short initial_env_height(BOOL adsr_on, unsigned char gain);
+void initialize_envelope(struct channel_state *c);
 void load_pattern(void);
 BOOL do_cycle_no_sound(struct song_state *st);
 BOOL do_timer(void);

--- a/src/inst.c
+++ b/src/inst.c
@@ -70,7 +70,7 @@ static void note_off(int note) {
 	for (int ch = 0; ch < 8; ch++)
 		if (state.chan[ch].samp_pos >= 0 && cnote[ch] == note) {
 			state.chan[ch].note_release = 0;
-			state.chan[ch].env_state = ENV_STATE_KEY_OFF;
+			state.chan[ch].next_env_state = ENV_STATE_KEY_OFF;
 		}
 	draw_square(note, GetStockObject(WHITE_BRUSH));
 }

--- a/src/inst.c
+++ b/src/inst.c
@@ -91,12 +91,7 @@ static void note_on(int note, int velocity) {
 	c->samp = &samp[spc[inst_base + 6*c->inst]];
 
 	c->note_release = 1;
-	c->env_height = initial_env_height(c->inst_adsr1 & 0x80, c->inst_gain);
-	c->next_env_height = c->env_height;
-	c->env_state = (c->inst_adsr1 & 0x80) ? ENV_STATE_ATTACK : ENV_STATE_GAIN;
-	c->next_env_state = c->env_state;
-	c->env_counter = 0;
-	c->env_fractional_counter = 0;
+	initialize_envelope(c);
 	calc_freq(c, note << 8);
 	c->left_vol = c->right_vol = min(max(velocity, 0), 127);
 	draw_square(note, (HBRUSH)(COLOR_HIGHLIGHT + 1));

--- a/src/inst.c
+++ b/src/inst.c
@@ -68,8 +68,10 @@ static void draw_square(int note, HBRUSH brush) {
 
 static void note_off(int note) {
 	for (int ch = 0; ch < 8; ch++)
-		if (state.chan[ch].samp_pos >= 0 && cnote[ch] == note)
+		if (state.chan[ch].samp_pos >= 0 && cnote[ch] == note) {
 			state.chan[ch].note_release = 0;
+			state.chan[ch].env_state = ENV_STATE_KEY_OFF;
+		}
 	draw_square(note, GetStockObject(WHITE_BRUSH));
 }
 
@@ -89,7 +91,8 @@ static void note_on(int note, int velocity) {
 	c->samp = &samp[spc[inst_base + 6*c->inst]];
 
 	c->note_release = 1;
-	c->env_height = 1;
+	c->env_height = 0;
+	c->env_state = ENV_STATE_ATTACK;
 	calc_freq(c, note << 8);
 	c->left_vol = c->right_vol = min(max(velocity, 0), 127);
 	draw_square(note, (HBRUSH)(COLOR_HIGHLIGHT + 1));

--- a/src/inst.c
+++ b/src/inst.c
@@ -36,7 +36,7 @@ static struct window_template inst_list_template = {
 	inst_list_template_num, inst_list_template_lower, 0, 0, inst_list_controls
 };
 
-static unsigned char valid_insts[64];
+static unsigned char valid_insts[MAX_INSTRUMENTS];
 static int cnote[8];
 
 int note_from_key(int key, BOOL shift) {
@@ -210,7 +210,7 @@ LRESULT CALLBACK InstrumentsWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM 
 		}
 
 		unsigned char *p = valid_insts;
-		for (int i = 0; i < 64; i++) { //filling out the Instrument Config ListBox
+		for (int i = 0; i < MAX_INSTRUMENTS; i++) { //filling out the Instrument Config ListBox
 			unsigned char *inst = &spc[inst_base + i*6];
 			if (inst[4] == 0 && inst[5] == 0) continue;
 			//            Index ADSR            Tuning

--- a/src/inst.c
+++ b/src/inst.c
@@ -91,10 +91,10 @@ static void note_on(int note, int velocity) {
 	c->samp = &samp[spc[inst_base + 6*c->inst]];
 
 	c->note_release = 1;
-	c->env_height = 0;
-	c->next_env_height = 0;
-	c->env_state = ENV_STATE_ATTACK;
-	c->next_env_state = ENV_STATE_ATTACK;
+	c->env_height = initial_env_height(c->inst_adsr1 & 0x80, c->inst_gain);
+	c->next_env_height = c->env_height;
+	c->env_state = (c->inst_adsr1 & 0x80) ? ENV_STATE_ATTACK : ENV_STATE_GAIN;
+	c->next_env_state = c->env_state;
 	c->env_counter = 0;
 	c->env_fractional_counter = 0;
 	calc_freq(c, note << 8);

--- a/src/inst.c
+++ b/src/inst.c
@@ -92,7 +92,11 @@ static void note_on(int note, int velocity) {
 
 	c->note_release = 1;
 	c->env_height = 0;
+	c->next_env_height = 0;
 	c->env_state = ENV_STATE_ATTACK;
+	c->next_env_state = ENV_STATE_ATTACK;
+	c->env_counter = 0;
+	c->env_fractional_counter = 0;
 	calc_freq(c, note << 8);
 	c->left_vol = c->right_vol = min(max(velocity, 0), 127);
 	draw_square(note, (HBRUSH)(COLOR_HIGHLIGHT + 1));

--- a/src/inst.c
+++ b/src/inst.c
@@ -212,7 +212,9 @@ LRESULT CALLBACK InstrumentsWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM 
 		unsigned char *p = valid_insts;
 		for (int i = 0; i < MAX_INSTRUMENTS; i++) { //filling out the Instrument Config ListBox
 			unsigned char *inst = &spc[inst_base + i*6];
-			if (inst[4] == 0 && inst[5] == 0) continue;
+			if (!samp[inst[0]].data
+				|| inst[0] >= 128
+				|| (inst[4] == 0 && inst[5] == 0)) continue;
 			//            Index ADSR            Tuning
 			sprintf(buf, "%02X: %02X %02X %02X  %02X%02X",
 				inst[0], inst[1], inst[2], inst[3], inst[4], inst[5]);

--- a/src/play.c
+++ b/src/play.c
@@ -244,7 +244,11 @@ static void do_note(struct song_state *st, struct channel_state *c, int note) {
 		c->samp_pos = 0;
 		c->samp = &samp[spc[inst_base + 6*c->inst]];
 		c->env_height = 0;
+		c->next_env_height = 0;
 		c->env_state = ENV_STATE_ATTACK;
+		c->next_env_state = ENV_STATE_ATTACK;
+		c->env_counter = 0;
+		c->env_fractional_counter = 0;
 
 		note &= 0x7F;
 		note += st->transpose + c->transpose;

--- a/src/play.c
+++ b/src/play.c
@@ -330,7 +330,7 @@ static void CF7(struct channel_state *c) {
 		c->note_release--;
 	}
 	if (c->note_release == 0) {
-		c->env_state = ENV_STATE_KEY_OFF;
+		c->next_env_state = ENV_STATE_KEY_OFF;
 	}
 
 	// 0D60

--- a/src/play.c
+++ b/src/play.c
@@ -72,7 +72,7 @@ void set_inst(struct song_state *st, struct channel_state *c, int inst) {
 		inst += st->first_CA_inst - 0xCA;
 
 	BYTE *idata = &spc[inst_base + 6*inst];
-	if (inst < 0 || inst >= 64 || !samp[idata[0]].data ||
+	if (inst < 0 || inst >= MAX_INSTRUMENTS || !samp[idata[0]].data ||
 		(idata[4] == 0 && idata[5] == 0))
 	{
 		printf("ch %d: bad inst %X\n", c - st->chan, inst);

--- a/src/play.c
+++ b/src/play.c
@@ -528,6 +528,7 @@ void initialize_state() {
 		state.chan[i].volume.cur = 0xFF00;
 		state.chan[i].panning.cur = 0x0A00;
 		state.chan[i].samp_pos = -1;
+		set_inst(&state, &state.chan[i], 0);
 	}
 	state.volume.cur = 0xC000;
 	state.tempo.cur = 0x2000;

--- a/src/sound.c
+++ b/src/sound.c
@@ -95,7 +95,7 @@ static BOOL do_envelope(struct channel_state *c, int mixing_rate) {
 		case ENV_STATE_DECAY:
 			if (c->env_counter >= c->decay_rate) {
 				c->env_counter = 0;
-				c->next_env_height = c->env_height - ((c->env_height - 1) >> 8) + 1;
+				c->next_env_height = c->env_height - (((c->env_height - 1) >> 8) + 1);
 			}
 			if (c->next_env_height <= c->sustain_level) {
 				c->next_env_state = ENV_STATE_SUSTAIN;
@@ -104,7 +104,7 @@ static BOOL do_envelope(struct channel_state *c, int mixing_rate) {
 		case ENV_STATE_SUSTAIN:
 			if (c->sustain_rate != 0 && c->env_counter >= c->sustain_rate) {
 				c->env_counter = 0;
-				c->next_env_height = c->env_height - ((c->env_height - 1) >> 8) + 1;
+				c->next_env_height = c->env_height - (((c->env_height - 1) >> 8) + 1);
 			}
 			break;
 		case ENV_STATE_KEY_OFF:

--- a/src/sound.c
+++ b/src/sound.c
@@ -199,7 +199,7 @@ static void fill_buffer() {
 
 			// Linear interpolation between envelope ticks
 			int env_height = c->env_height +
-                (c->next_env_height - c->env_height) * c->env_fractional_counter / mixrate;
+			    (c->next_env_height - c->env_height) * c->env_fractional_counter / mixrate;
 			left  += s1 * c->env_height / 0x800 * c->left_vol  / 128;
 			right += s1 * c->env_height / 0x800 * c->right_vol / 128;
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -77,13 +77,19 @@ struct song_state {
 		struct sample *samp;
 		int samp_pos, note_freq;
 
+		// Envelope state for the current/previous 32 KHz tick...
 		enum envelope_state {
 			ENV_STATE_ATTACK,
 			ENV_STATE_DECAY,
 			ENV_STATE_SUSTAIN,
 			ENV_STATE_KEY_OFF
 		} env_state;
-		short env_height; // envelope height
+		// ...and for the next 32 KHz tick
+		enum envelope_state next_env_state;
+		// Envelope height for the current/previous 32 KHz tick...
+		short env_height;
+		// ...and for the next 32 KHz tick, for interpolation purposes
+		short next_env_height;
 		unsigned short env_counter;
 		unsigned env_fractional_counter;
 		short attack_rate;

--- a/src/structs.h
+++ b/src/structs.h
@@ -83,8 +83,13 @@ struct song_state {
 			ENV_STATE_SUSTAIN,
 			ENV_STATE_KEY_OFF
 		} env_state;
-		double env_height; // envelope height
-		double decay_rate;
+		short env_height; // envelope height
+		unsigned short env_counter;
+		unsigned env_fractional_counter;
+		short attack_rate;
+		short decay_rate;
+		short sustain_level;
+		short sustain_rate;
 	} chan[16];
 	signed char transpose;
 	struct slider volume;

--- a/src/structs.h
+++ b/src/structs.h
@@ -57,6 +57,8 @@ struct song_state {
 
 		BYTE inst; // instrument
 		BYTE inst_adsr1;
+		BYTE inst_adsr2;
+		BYTE inst_gain;
 		BYTE finetune;
 		signed char transpose;
 		struct slider panning; BYTE pan_flags;
@@ -75,6 +77,12 @@ struct song_state {
 		struct sample *samp;
 		int samp_pos, note_freq;
 
+		enum envelope_state {
+			ENV_STATE_ATTACK,
+			ENV_STATE_DECAY,
+			ENV_STATE_SUSTAIN,
+			ENV_STATE_KEY_OFF
+		} env_state;
 		double env_height; // envelope height
 		double decay_rate;
 	} chan[16];

--- a/src/structs.h
+++ b/src/structs.h
@@ -82,7 +82,8 @@ struct song_state {
 			ENV_STATE_ATTACK,
 			ENV_STATE_DECAY,
 			ENV_STATE_SUSTAIN,
-			ENV_STATE_KEY_OFF
+			ENV_STATE_KEY_OFF,
+			ENV_STATE_GAIN
 		} env_state;
 		// ...and for the next 32 KHz tick
 		enum envelope_state next_env_state;
@@ -96,6 +97,7 @@ struct song_state {
 		short decay_rate;
 		short sustain_level;
 		short sustain_rate;
+		short gain_rate;
 	} chan[16];
 	signed char transpose;
 	struct slider volume;


### PR DESCRIPTION
This PR fixes #28 and adds support for all phases of the SNES's ADSR envelope and both of the "increase" options of the SNES's "custom GAIN" envelope, with linear interpolation that scales nicely with the current sample rate of the program. (The decreasing GAIN options and the ability to switch between GAIN and ADSR accurately aren't implemented, because they're mostly useless. EarthBound's flavor of N-SPC doesn't change the envelope settings mid note or anything.)

I haven't gotten around to testing all of this yet. I have tested ADSR to a degree I'm satisfied with on MinGW-W64, using some of Livvy's music that had custom attack, but I haven't tried building with MSVC yet, and I haven't experimented with GAIN at all yet.

This could still use some cleanup, obviously. But the tested parts work and sound good.