### PR TITLE
Make compilation error out on variable-length arrays

### DIFF
--- a/ide/codeblocks/ebmused.cbp
+++ b/ide/codeblocks/ebmused.cbp
@@ -12,8 +12,9 @@
 				<Option type="1" />
 				<Option compiler="gcc" />
 				<Compiler>
-					<Add option="-g" />
 					<Add option="-Og" />
+					<Add option="-g" />
+					<Add option="-Werror=vla" />
 				</Compiler>
 			</Target>
 			<Target title="Release">
@@ -23,6 +24,7 @@
 				<Option compiler="gcc" />
 				<Compiler>
 					<Add option="-O2" />
+					<Add option="-Werror=vla" />
 				</Compiler>
 				<Linker>
 					<Add option="-s" />

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 O = bgmlist.o brr.o ctrltbl.o help.o inst.o loadrom.o main.o metadata.o midi.o misc.o packlist.o packs.o parser.o play.o ranges.o resource.o song.o songed.o sound.o text.o tracker.o
-CC = gcc -DNDEBUG -Os -W -Wall -std=gnu99
+CC = gcc -DNDEBUG -Os -W -Wall -Werror=vla -std=gnu99
 
 a.exe: $O
 	gcc -mwindows -s -fno-exceptions $O -lcomctl32 -lcomdlg32 -lgdi32 -lwinmm -Wl,ldscript


### PR DESCRIPTION
MSVC doesn't support VLAs, so this will help make writing code that works with different compilers easier.