### PR TITLE
Dynamically determine song pointer table location

### DIFF
--- a/src/bgmlist.c
+++ b/src/bgmlist.c
@@ -244,7 +244,7 @@ write_error:	MessageBox2(strerror(errno), "Save", MB_ICONERROR);
 				break;
 			}
 			memcpy(&pack_used[selected_bgm], new_pack_used, 3);
-			fseek(rom, SONG_POINTER_TABLE + rom_offset + 2 * selected_bgm, SEEK_SET);
+			fseek(rom, song_pointer_table_offset + 2 * selected_bgm, SEEK_SET);
 			if (!fwrite(&new_spc_address, 2, 1, rom))
 				goto write_error;
 			song_address[selected_bgm] = new_spc_address;

--- a/src/ebmusv2.h
+++ b/src/ebmusv2.h
@@ -10,7 +10,9 @@
 #define NUM_PACKS 0xA9
 #define BGM_PACK_TABLE 0x4F70A
 #define PACK_POINTER_TABLE 0x4F947
-#define SONG_POINTER_TABLE 0x26298C
+// This value is now determined dynamically based on the location of pack 1.
+// See song_pointer_table_offset.
+// #define SONG_POINTER_TABLE 0x26298C
 
 // other constants and stuff
 #define MAX_TITLE_LEN 60
@@ -123,6 +125,7 @@ extern FILE *rom;
 #endif
 extern int rom_size;
 extern int rom_offset;
+extern int song_pointer_table_offset;
 extern char *rom_filename;
 extern unsigned char pack_used[NUM_SONGS][3];
 extern unsigned short song_address[NUM_SONGS];


### PR DESCRIPTION
Previously, it was assumed that the song pointer table was at a fixed location in the ROM. However, with CoilSnake 4.2 beta 1 and newer, all of the song packs, including the engine containing the song pointer table, can be relocated.

In order to open ROMs compiled by this version of CoilSnake, when loading all of the packs we now check if the current block is the main engine block, and if so, save the address in the file of the song pointer table based on that block's address.