### PR TITLE
Fix some undefined behavior in making and unmaking subroutines

### DIFF
--- a/src/tracker.c
+++ b/src/tracker.c
@@ -1106,7 +1106,7 @@ void editor_command(int id) {
 
 		// Try to merge the "created" subroutine with pre-existing subroutine commands
 		// immediately before and after it
-		if (start >= (t->track + 4)
+		if (start - t->track >= 4
 			&& start[-4] == 0xEF
 			&& (start[-3] | (start[-2] << 8)) == sub
 			&& count + start[-1] <= 255)


### PR DESCRIPTION
Fixes [the heap corruption issue Livvy ran into](https://youtu.be/Lr-L1h87710?t=99) with making and unmaking subroutines. While I was in that file, I added some comments and got rid of some pointer casting.