### PR TITLE
Fixed instruments tab stops working when sound options is opened

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -659,6 +659,10 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 		case ID_OPTIONS: {
 			extern BOOL CALLBACK OptionsDlgProc(HWND,UINT,WPARAM,LPARAM);
 			DialogBox(hinstance, MAKEINTRESOURCE(IDD_OPTIONS), hWnd, OptionsDlgProc);
+			if (current_tab == INST_TAB) {
+				// Re-enable playback for the instruments tab...
+				start_playing();
+			}
 			break;
 		}
 		case ID_CUT:

--- a/src/sound.c
+++ b/src/sound.c
@@ -343,7 +343,8 @@ BOOL CALLBACK OptionsDlgProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	case WM_INITDIALOG:
 		SetDlgItemInt(hWnd, IDC_RATE, mixrate, FALSE);
 		SetDlgItemInt(hWnd, IDC_BUFSIZE, bufsize, FALSE);
-		song_playing = FALSE;
+		stop_playing();
+		EnableMenuItem(hmenu, ID_PLAY, MF_ENABLED);
 		break;
 	case WM_COMMAND:
 		switch (LOWORD(wParam)) {


### PR DESCRIPTION
https://github.com/PKHackers/ebmused/issues/25

The instruments tab functionality now gets restored after the Sound Options window closes.