### PR TITLE
Fixed importing SPC music pack

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -358,6 +358,8 @@ static void import_spc() {
 			}
 
 			initialize_state();
+			cur_song.changed = TRUE;
+			save_cur_song_to_pack();
 			SendMessage(tab_hwnd[current_tab], WM_SONG_IMPORTED, 0, 0);
 		} else {
 			// Restore SPC state and samples


### PR DESCRIPTION
Fixed the issue where importing an SPC wouldn't generate a new music pack for the selected track.

Previously the user would have to make a change on the tracker tab for a pack to be generated, but now it gets generated on import.
See issue #42 