### PR TITLE
Fix MSVC build errors

### DIFF
--- a/ide/vs2019/ebmused.sln
+++ b/ide/vs2019/ebmused.sln
@@ -7,12 +7,18 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ebmused", "ebmused.vcxproj"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{490C16A6-0881-4332-A0E9-9E7CAF569779}.Debug|x64.ActiveCfg = Debug|x64
+		{490C16A6-0881-4332-A0E9-9E7CAF569779}.Debug|x64.Build.0 = Debug|x64
 		{490C16A6-0881-4332-A0E9-9E7CAF569779}.Debug|x86.ActiveCfg = Debug|Win32
 		{490C16A6-0881-4332-A0E9-9E7CAF569779}.Debug|x86.Build.0 = Debug|Win32
+		{490C16A6-0881-4332-A0E9-9E7CAF569779}.Release|x64.ActiveCfg = Release|x64
+		{490C16A6-0881-4332-A0E9-9E7CAF569779}.Release|x64.Build.0 = Release|x64
 		{490C16A6-0881-4332-A0E9-9E7CAF569779}.Release|x86.ActiveCfg = Release|Win32
 		{490C16A6-0881-4332-A0E9-9E7CAF569779}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection

--- a/ide/vs2019/ebmused.vcxproj
+++ b/ide/vs2019/ebmused.vcxproj
@@ -69,7 +69,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup />
-    <PropertyGroup>
+  <PropertyGroup>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -109,7 +109,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>gdi32.lib;user32.lib;kernel32.lib;comdlg32.lib;comctl32.lib;winmm.lib</AdditionalDependencies>
+      <AdditionalDependencies>gdi32.lib;user32.lib;kernel32.lib;comdlg32.lib;comctl32.lib;winmm.lib;shell32.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -124,7 +124,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>gdi32.lib;user32.lib;kernel32.lib;comdlg32.lib;comctl32.lib;winmm.lib</AdditionalDependencies>
+      <AdditionalDependencies>gdi32.lib;user32.lib;kernel32.lib;comdlg32.lib;comctl32.lib;winmm.lib;shell32.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/help.c
+++ b/src/help.c
@@ -147,11 +147,12 @@ LRESULT CALLBACK CodeListWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPa
 static WNDPROC HomepageLinkWndProc;
 static LRESULT CALLBACK HomepageLinkProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 	switch (uMsg) {
-		case WM_SETCURSOR:
+		case WM_SETCURSOR: {
 			HCURSOR hCursor = LoadCursor(NULL, IDC_HAND);
 			if (NULL == hCursor) hCursor = LoadCursor(NULL, IDC_ARROW);
 			SetCursor(hCursor);
 			return TRUE;
+		}
 	}
 
 	return CallWindowProc(HomepageLinkWndProc, hWnd, uMsg, wParam, lParam);
@@ -159,7 +160,7 @@ static LRESULT CALLBACK HomepageLinkProc(HWND hWnd, UINT uMsg, WPARAM wParam, LP
 
 BOOL CALLBACK AboutDlgProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 	switch(uMsg) {
-		case WM_INITDIALOG:
+		case WM_INITDIALOG: {
 			HWND hwndLink = GetDlgItem(hWnd, IDC_HOMEPAGELINK);
 			HomepageLinkWndProc = (WNDPROC)SetWindowLongPtr(hwndLink, GWLP_WNDPROC, (LONG_PTR)HomepageLinkProc);
 
@@ -173,6 +174,7 @@ BOOL CALLBACK AboutDlgProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 			SetTextColor(hwndLink, RGB(0, 0, 192));
 
 			break;
+		}
 		case WM_COMMAND:
 			switch(LOWORD(wParam)) {
 				case IDC_HOMEPAGELINK:

--- a/src/resource.rc
+++ b/src/resource.rc
@@ -128,8 +128,7 @@ STYLE 0
 CAPTION "About"
 FONT 8, "MS Shell Dlg"
 BEGIN
-	LTEXT "EarthBound Music Editor\r\n"
-		"v2.5.0\r\n", 0,
+	LTEXT "EarthBound Music Editor\r\nv2.5.0\r\n", 0,
 		5, 5, 170, 55
 	CONTROL "https://github.com/PKHackers/ebmused/", IDC_HOMEPAGELINK, "Static", SS_NOTIFY | WS_GROUP | WS_TABSTOP,
 		5, 30, 170, 8

--- a/src/status.c
+++ b/src/status.c
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include <commctrl.h>
 #include <stdarg.h>
+#include <stdlib.h>
 
 void format_status(int part, const char* format, ...) {
 	if (hwndStatus) {


### PR DESCRIPTION
- Link with shell32.dll in Release builds. This is needed for ShellExecute in the help dialog.
- Add x64 platform to the solution, not just the project. We probably want to be making x64 builds now so that people on arm64 Macs can use x64 Wine, since it can't run 32-bit programs.
- Fix a few implicit function definitions and issues with labels on declarations I found in the build output and after opening help.c in the IDE.