### PR TITLE
A few fixes for envelopes and the instrument test screen

### DIFF
--- a/src/play.c
+++ b/src/play.c
@@ -232,7 +232,7 @@ static short initial_env_height(BOOL adsr_on, unsigned char gain) {
 	if (adsr_on || (gain & 0x80))
 		return 0;
 	else
-		return (gain & 0x7F) * 16 / 0x800;
+		return (gain & 0x7F) * 16;
 }
 
 void initialize_envelope(struct channel_state *c) {


### PR DESCRIPTION
- Direct gain now actually works... Not testing that was clearly a bad call. It was a dumb typo too, I misread fullsnes.
- Reorder a bounds check for accessing the array of samples that's been bugging me for a while. This check seems to prevent noise instruments from being added to the instrument list, but I didn't really check that.
- Add status bar text for gain envelopes. When testing, I noticed that it said "ADSR" at the bottom and that bugged me again.