### PR TITLE
Fix edge case in transpose handling for 0xF9

### DIFF
--- a/src/play.c
+++ b/src/play.c
@@ -216,7 +216,7 @@ static void do_command(struct song_state *st, struct channel_state *c) {
 			break;
 		case 0xF9: {
 			c->cur_port_start_ctr = p[1];
-			int target = p[3] + st->transpose;
+			int target = p[3] + (unsigned char)st->transpose;
 			if (target >= 0x100) target -= 0xFF;
 			target += c->transpose;
 			make_slider(&c->note, p[2], target & 0x7F);


### PR DESCRIPTION
Using a negative transpose can cause unsigned overflow in the addition, which will set the carry flag. ebmused was only handling that properly for large positive transpositions.

Fixes an issue that Livvy and Crafty ran into but that wasn't reported or investigated until now.

To-do list:

- [ ] Should we add a warning in the code list about this or something?
- [ ] Test that it still builds on MSVC